### PR TITLE
DELETE repository will return 204, not 200

### DIFF
--- a/specification/git/5.0/git.json
+++ b/specification/git/5.0/git.json
@@ -1020,7 +1020,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": "successful operation"
           }
         },


### PR DESCRIPTION
Both the example and experience suggests that it should be a 204, and not 200 for the DELETE operation.