### PR TITLE
Ensure operationId’s are unique

### DIFF
--- a/specification/core/4.1/core.json
+++ b/specification/core/4.1/core.json
@@ -45,7 +45,7 @@
         "x-ms-vss-resource": "processes",
         "x-ms-vss-method": "GetProcesses",
         "description": "Get a list of processes.",
-        "operationId": "List",
+        "operationId": "ListProcesses",
         "produces": [
           "application/json"
         ],
@@ -90,7 +90,7 @@
         "x-ms-vss-resource": "processes",
         "x-ms-vss-method": "GetProcessById",
         "description": "Get a process by ID.",
-        "operationId": "Get",
+        "operationId": "GetProcessById",
         "produces": [
           "application/json"
         ],
@@ -140,7 +140,7 @@
         "x-ms-vss-resource": "projects",
         "x-ms-vss-method": "GetProjects",
         "description": "Get all projects in the organization that the authenticated user has access to.",
-        "operationId": "List",
+        "operationId": "ListProjects",
         "produces": [
           "application/json"
         ],
@@ -261,7 +261,7 @@
         "x-ms-vss-resource": "projects",
         "x-ms-vss-method": "QueueCreateProject",
         "description": "Queues a project to be created. Use the [GetOperation](../../operations/operations/get) to periodically check for create project status.",
-        "operationId": "Create",
+        "operationId": "CreateProject",
         "consumes": [
           "application/json"
         ],
@@ -320,7 +320,7 @@
         "x-ms-vss-resource": "projects",
         "x-ms-vss-method": "GetProject",
         "description": "Get project with the specified id or name, optionally including capabilities.",
-        "operationId": "Get",
+        "operationId": "GetProject",
         "produces": [
           "application/json"
         ],
@@ -382,7 +382,7 @@
         "x-ms-vss-resource": "projects",
         "x-ms-vss-method": "QueueDeleteProject",
         "description": "Queues a project to be deleted. Use the [GetOperation](../../operations/operations/get) to periodically check for delete project status.",
-        "operationId": "Delete",
+        "operationId": "DeleteProject",
         "produces": [
           "application/json"
         ],
@@ -430,7 +430,7 @@
         "x-ms-vss-resource": "projects",
         "x-ms-vss-method": "UpdateProject",
         "description": "Update an existing project's name, abbreviation, or description.",
-        "operationId": "Update",
+        "operationId": "UpdateProject",
         "consumes": [
           "application/json"
         ],
@@ -626,7 +626,7 @@
         "x-ms-vss-resource": "teams",
         "x-ms-vss-method": "CreateTeam",
         "description": "Create a team in a team project.\n\nPossible failure scenarios\nInvalid project name/ID (project doesn't exist) 404\nInvalid team name or description 400\nTeam already exists 400\nInsufficient privileges 400",
-        "operationId": "Create",
+        "operationId": "CreateTeam",
         "consumes": [
           "application/json"
         ],
@@ -771,7 +771,7 @@
         "x-ms-vss-resource": "teams",
         "x-ms-vss-method": "DeleteTeam",
         "description": "Delete a team.",
-        "operationId": "Delete",
+        "operationId": "DeleteTeam",
         "parameters": [
           {
             "in": "path",
@@ -824,7 +824,7 @@
         "x-ms-vss-resource": "teams",
         "x-ms-vss-method": "GetTeam",
         "description": "Get a specific team.",
-        "operationId": "Get",
+        "operationId": "GetTeam",
         "produces": [
           "application/json"
         ],
@@ -884,7 +884,7 @@
         "x-ms-vss-resource": "teams",
         "x-ms-vss-method": "UpdateTeam",
         "description": "Update a team's name and/or description.",
-        "operationId": "Update",
+        "operationId": "UpdateTeam",
         "consumes": [
           "application/json"
         ],

--- a/specification/core/5.0/core.json
+++ b/specification/core/5.0/core.json
@@ -45,7 +45,7 @@
         "x-ms-vss-resource": "processes",
         "x-ms-vss-method": "GetProcesses",
         "description": "Get a list of processes.",
-        "operationId": "List",
+        "operationId": "ListProcesses",
         "produces": [
           "application/json"
         ],
@@ -90,7 +90,7 @@
         "x-ms-vss-resource": "processes",
         "x-ms-vss-method": "GetProcessById",
         "description": "Get a process by ID.",
-        "operationId": "Get",
+        "operationId": "GetProcessById",
         "produces": [
           "application/json"
         ],
@@ -140,7 +140,7 @@
         "x-ms-vss-resource": "projects",
         "x-ms-vss-method": "GetProjects",
         "description": "Get all projects in the organization that the authenticated user has access to.",
-        "operationId": "List",
+        "operationId": "ListProjects",
         "produces": [
           "application/json"
         ],
@@ -268,7 +268,7 @@
         "x-ms-vss-resource": "projects",
         "x-ms-vss-method": "QueueCreateProject",
         "description": "Queues a project to be created. Use the [GetOperation](../../operations/operations/get) to periodically check for create project status.",
-        "operationId": "Create",
+        "operationId": "CreateProject",
         "consumes": [
           "application/json"
         ],
@@ -327,7 +327,7 @@
         "x-ms-vss-resource": "projects",
         "x-ms-vss-method": "GetProject",
         "description": "Get project with the specified id or name, optionally including capabilities.",
-        "operationId": "Get",
+        "operationId": "GetProject",
         "produces": [
           "application/json"
         ],
@@ -389,7 +389,7 @@
         "x-ms-vss-resource": "projects",
         "x-ms-vss-method": "QueueDeleteProject",
         "description": "Queues a project to be deleted. Use the [GetOperation](../../operations/operations/get) to periodically check for delete project status.",
-        "operationId": "Delete",
+        "operationId": "DeleteProject",
         "produces": [
           "application/json"
         ],
@@ -437,7 +437,7 @@
         "x-ms-vss-resource": "projects",
         "x-ms-vss-method": "UpdateProject",
         "description": "Update an existing project's name, abbreviation, or description.",
-        "operationId": "Update",
+        "operationId": "UpdateProject",
         "consumes": [
           "application/json"
         ],
@@ -633,7 +633,7 @@
         "x-ms-vss-resource": "teams",
         "x-ms-vss-method": "CreateTeam",
         "description": "Create a team in a team project.\n\nPossible failure scenarios\nInvalid project name/ID (project doesn't exist) 404\nInvalid team name or description 400\nTeam already exists 400\nInsufficient privileges 400",
-        "operationId": "Create",
+        "operationId": "CreateTeam",
         "consumes": [
           "application/json"
         ],
@@ -778,7 +778,7 @@
         "x-ms-vss-resource": "teams",
         "x-ms-vss-method": "DeleteTeam",
         "description": "Delete a team.",
-        "operationId": "Delete",
+        "operationId": "DeleteTeam",
         "parameters": [
           {
             "in": "path",
@@ -831,7 +831,7 @@
         "x-ms-vss-resource": "teams",
         "x-ms-vss-method": "GetTeam",
         "description": "Get a specific team.",
-        "operationId": "Get",
+        "operationId": "GetTeam",
         "produces": [
           "application/json"
         ],
@@ -891,7 +891,7 @@
         "x-ms-vss-resource": "teams",
         "x-ms-vss-method": "UpdateTeam",
         "description": "Update a team's name and/or description.",
-        "operationId": "Update",
+        "operationId": "UpdateTeam",
         "consumes": [
           "application/json"
         ],

--- a/specification/core/5.1/core.json
+++ b/specification/core/5.1/core.json
@@ -49,7 +49,7 @@
         "x-ms-vss-method": "GetProcesses",
         "x-ms-preview": true,
         "description": "Get a list of processes.",
-        "operationId": "List",
+        "operationId": "ListProcesses",
         "produces": [
           "application/json"
         ],
@@ -95,7 +95,7 @@
         "x-ms-vss-method": "GetProcessById",
         "x-ms-preview": true,
         "description": "Get a process by ID.",
-        "operationId": "Get",
+        "operationId": "GetProcessById",
         "produces": [
           "application/json"
         ],
@@ -146,7 +146,7 @@
         "x-ms-vss-method": "GetProjects",
         "x-ms-preview": true,
         "description": "Get all projects in the organization that the authenticated user has access to.",
-        "operationId": "List",
+        "operationId": "ListProjects",
         "produces": [
           "application/json"
         ],
@@ -275,7 +275,7 @@
         "x-ms-vss-method": "QueueCreateProject",
         "x-ms-preview": true,
         "description": "Queues a project to be created. Use the [GetOperation](../../operations/operations/get) to periodically check for create project status.",
-        "operationId": "Create",
+        "operationId": "CreateProject",
         "consumes": [
           "application/json"
         ],
@@ -335,7 +335,7 @@
         "x-ms-vss-method": "GetProject",
         "x-ms-preview": true,
         "description": "Get project with the specified id or name, optionally including capabilities.",
-        "operationId": "Get",
+        "operationId": "GetProject",
         "produces": [
           "application/json"
         ],
@@ -398,7 +398,7 @@
         "x-ms-vss-method": "QueueDeleteProject",
         "x-ms-preview": true,
         "description": "Queues a project to be deleted. Use the [GetOperation](../../operations/operations/get) to periodically check for delete project status.",
-        "operationId": "Delete",
+        "operationId": "DeleteProject",
         "produces": [
           "application/json"
         ],
@@ -447,7 +447,7 @@
         "x-ms-vss-method": "UpdateProject",
         "x-ms-preview": true,
         "description": "Update an existing project's name, abbreviation, description, or restore a project.",
-        "operationId": "Update",
+        "operationId": "UpdateProject",
         "consumes": [
           "application/json"
         ],
@@ -735,7 +735,7 @@
         "x-ms-vss-method": "CreateTeam",
         "x-ms-preview": true,
         "description": "Create a team in a team project.\n\nPossible failure scenarios\nInvalid project name/ID (project doesn't exist) 404\nInvalid team name or description 400\nTeam already exists 400\nInsufficient privileges 400",
-        "operationId": "Create",
+        "operationId": "CreateTeam",
         "consumes": [
           "application/json"
         ],
@@ -882,7 +882,7 @@
         "x-ms-vss-method": "DeleteTeam",
         "x-ms-preview": true,
         "description": "Delete a team.",
-        "operationId": "Delete",
+        "operationId": "DeleteTeam",
         "parameters": [
           {
             "in": "path",
@@ -936,7 +936,7 @@
         "x-ms-vss-method": "GetTeam",
         "x-ms-preview": true,
         "description": "Get a specific team.",
-        "operationId": "Get",
+        "operationId": "GetTeam",
         "produces": [
           "application/json"
         ],
@@ -997,7 +997,7 @@
         "x-ms-vss-method": "UpdateTeam",
         "x-ms-preview": true,
         "description": "Update a team's name and/or description.",
-        "operationId": "Update",
+        "operationId": "UpdateTeam",
         "consumes": [
           "application/json"
         ],


### PR DESCRIPTION
Attempting to generate a client use go-swagger throws the following errors:

```
2019/05/01 22:25:08 validating spec core.json
The swagger spec at "core.json" is invalid against swagger specification 2.0. see errors :
- "Update" is defined 2 times
- "Delete" is defined 2 times
- "List" is defined 2 times
- "Create" is defined 2 times
- "Get" is defined 3 times
```

This PR fixes the above issues for core. If accepted, I can walk through all the other spec files as well other specs as well.