### PR TITLE
"create-a-fork-of-a-parent-repository" example does not work

### DIFF
--- a/specification/git/5.1/httpExamples/repositories/POST__git_repositories_fork.json
+++ b/specification/git/5.1/httpExamples/repositories/POST__git_repositories_fork.json
@@ -9,6 +9,7 @@
       },
       "parentRepository": {
         "name": "MyFirstRepo",
+        "id": "aeb3259f-bc8c-4898-87e2-86354905c2d2",
         "project": {
           "name": "MyFirstProject"
         }


### PR DESCRIPTION
I opened a bug for this issue, https://github.com/MicrosoftDocs/feedback/issues/2037

I got exception ""innerException":null,"message":"The guid specified for parameter repositoryId must not be Guid.Empty.\r\nParameter name: repositoryId","

The problem is that for "parentRepository", the name property is not enough, id property should be provided as well.