### PR TITLE
Add Description for Query Metrics

### DIFF
--- a/specification/artifacts/6.1/feed.json
+++ b/specification/artifacts/6.1/feed.json
@@ -889,7 +889,7 @@
         "x-ms-vss-resource": "packageMetricsBatch",
         "x-ms-vss-method": "QueryPackageMetrics",
         "x-ms-preview": true,
-        "description": "",
+        "description": "Query the metrics for one or more packages.\n\nThe project parameter must be supplied if the feed was created in a project.\nIf the feed is not associated with any project, omit the project parameter from the request.",
         "operationId": "Artifact  Details_Query Package Metrics",
         "consumes": [
           "application/json"
@@ -917,7 +917,7 @@
           {
             "in": "path",
             "name": "feedId",
-            "description": "",
+            "description": "Name or Id of the feed.",
             "required": true,
             "type": "string"
           },
@@ -1231,7 +1231,7 @@
         "x-ms-vss-resource": "versionMetricsBatch",
         "x-ms-vss-method": "QueryPackageVersionMetrics",
         "x-ms-preview": true,
-        "description": "",
+        "description": "Query the metrics for one or more package versions.\n\nThe project parameter must be supplied if the feed was created in a project.\nIf the feed is not associated with any project, omit the project parameter from the request.",
         "operationId": "Artifact  Details_Query Package Version Metrics",
         "consumes": [
           "application/json"
@@ -1259,14 +1259,14 @@
           {
             "in": "path",
             "name": "feedId",
-            "description": "",
+            "description": "Name or Id of the feed.",
             "required": true,
             "type": "string"
           },
           {
             "in": "path",
             "name": "packageId",
-            "description": "",
+            "description": "The package Id (GUID Id, not the package name).",
             "required": true,
             "type": "string",
             "format": "uuid"


### PR DESCRIPTION
The description for "Query Package Metrics" and "Query Package Version Metrics" currently shows the "GetBadge" description in docs.

![image](https://user-images.githubusercontent.com/11257591/94820648-520e2a00-03c6-11eb-8c43-113a9674df64.png)

https://docs.microsoft.com/en-us/rest/api/azure/devops/artifacts/artifact%20%20details?view=azure-devops-rest-6.1