### PR TITLE
Update API Request Example for Adding and Updating Comments

### DIFF
--- a/specification/wit/6.1/httpExamples/comments/PATCH__wit_workitems__taskId__comments_1.json
+++ b/specification/wit/6.1/httpExamples/comments/PATCH__wit_workitems__taskId__comments_1.json
@@ -3,11 +3,9 @@
     "project": "Fabrikam-Fiber-Git",
     "workItemId": "299",
     "commentId": "50",
-    "body": [
-      {
+    "body": {
         "text": "Moving to the right area path - Fabrikam-Git"
-      }
-    ],
+      },
     "accept": "application/json; api-version=5.1-preview",
     "organization": "fabrikam"
   },

--- a/specification/wit/6.1/httpExamples/comments/POST__wit_workitems__taskId__comments_create.json
+++ b/specification/wit/6.1/httpExamples/comments/POST__wit_workitems__taskId__comments_create.json
@@ -2,11 +2,9 @@
   "parameters": {
     "project": "Fabrikam-Fiber-Git",
     "workItemId": "299",
-    "body": [
-      {
+    "body": {
         "text": "Moving to the right area path"
-      }
-    ],
+      },
     "accept": "application/json; api-version=5.1-preview",
     "organization": "fabrikam"
   },


### PR DESCRIPTION
The example request body for adding and updating comments shows that an array of JSON object is required when creating an API call. However this throws a 400 Bad Request, with the following error message:
```
{"$id":"1","innerException":null,"message":"You must provide a value for the text parameter.","typeName":"Microsoft.VisualStudio.Services.Common.VssPropertyValidationException, Microsoft.VisualStudio.Services.Common","typeKey":"VssPropertyValidationException","errorCode":0,"eventId":3000}
```
In reality, just posting the JSON object alone is what the endpoints accept and a 200 is returned.