### PR TITLE
remove the byte order marks

### DIFF
--- a/specification/account/4.1/accounts.json
+++ b/specification/account/4.1/accounts.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Account",

--- a/specification/account/5.0/accounts.json
+++ b/specification/account/5.0/accounts.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Account",

--- a/specification/account/5.1/accounts.json
+++ b/specification/account/5.1/accounts.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Account",

--- a/specification/account/5.2/accounts.json
+++ b/specification/account/5.2/accounts.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Account",

--- a/specification/account/6.0/accounts.json
+++ b/specification/account/6.0/accounts.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Account",

--- a/specification/account/6.1/accounts.json
+++ b/specification/account/6.1/accounts.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Account",

--- a/specification/account/7.1/accounts.json
+++ b/specification/account/7.1/accounts.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Account",

--- a/specification/approvalsAndChecks/6.1/pipelinePermissions.json
+++ b/specification/approvalsAndChecks/6.1/pipelinePermissions.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PipelinePermissions",

--- a/specification/approvalsAndChecks/6.1/pipelinesChecks.json
+++ b/specification/approvalsAndChecks/6.1/pipelinesChecks.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PipelinesChecks",

--- a/specification/approvalsAndChecks/6.1/pipelinesapproval.json
+++ b/specification/approvalsAndChecks/6.1/pipelinesapproval.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Approval",

--- a/specification/approvalsAndChecks/7.1/pipelinePermissions.json
+++ b/specification/approvalsAndChecks/7.1/pipelinePermissions.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PipelinePermissions",

--- a/specification/approvalsAndChecks/7.1/pipelinesChecks.json
+++ b/specification/approvalsAndChecks/7.1/pipelinesChecks.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PipelinesChecks",

--- a/specification/approvalsAndChecks/7.1/pipelinesapproval.json
+++ b/specification/approvalsAndChecks/7.1/pipelinesapproval.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Approval",

--- a/specification/artifacts/5.0/feed.json
+++ b/specification/artifacts/5.0/feed.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Feed",

--- a/specification/artifacts/5.0/provenance.json
+++ b/specification/artifacts/5.0/provenance.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Provenance",

--- a/specification/artifacts/5.1/feed.json
+++ b/specification/artifacts/5.1/feed.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Feed",

--- a/specification/artifacts/5.1/provenance.json
+++ b/specification/artifacts/5.1/provenance.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Provenance",

--- a/specification/artifacts/5.2/feed.json
+++ b/specification/artifacts/5.2/feed.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Feed",

--- a/specification/artifacts/5.2/provenance.json
+++ b/specification/artifacts/5.2/provenance.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Provenance",

--- a/specification/artifacts/6.0/feed.json
+++ b/specification/artifacts/6.0/feed.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Feed",

--- a/specification/artifacts/6.0/provenance.json
+++ b/specification/artifacts/6.0/provenance.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Provenance",

--- a/specification/artifacts/6.1/feed.json
+++ b/specification/artifacts/6.1/feed.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Feed",

--- a/specification/artifacts/6.1/provenance.json
+++ b/specification/artifacts/6.1/provenance.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Provenance",

--- a/specification/artifacts/6.1/sbom.json
+++ b/specification/artifacts/6.1/sbom.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "SBOM",

--- a/specification/artifacts/7.1/feed.json
+++ b/specification/artifacts/7.1/feed.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Feed",

--- a/specification/artifacts/7.1/provenance.json
+++ b/specification/artifacts/7.1/provenance.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Provenance",

--- a/specification/artifacts/7.1/sbom.json
+++ b/specification/artifacts/7.1/sbom.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "SBOM",

--- a/specification/artifacts/azure-devops-server-5.0/feed-onprem.json
+++ b/specification/artifacts/azure-devops-server-5.0/feed-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Feed",

--- a/specification/artifactsPackageTypes/5.0/maven.json
+++ b/specification/artifactsPackageTypes/5.0/maven.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Maven",

--- a/specification/artifactsPackageTypes/5.0/npm.json
+++ b/specification/artifactsPackageTypes/5.0/npm.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Npm",

--- a/specification/artifactsPackageTypes/5.0/nuGet.json
+++ b/specification/artifactsPackageTypes/5.0/nuGet.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "NuGet",

--- a/specification/artifactsPackageTypes/5.0/pyPiApi.json
+++ b/specification/artifactsPackageTypes/5.0/pyPiApi.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PyPiApi",

--- a/specification/artifactsPackageTypes/5.0/universal.json
+++ b/specification/artifactsPackageTypes/5.0/universal.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "UPackApi",

--- a/specification/artifactsPackageTypes/5.1/maven.json
+++ b/specification/artifactsPackageTypes/5.1/maven.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Maven",

--- a/specification/artifactsPackageTypes/5.1/npm.json
+++ b/specification/artifactsPackageTypes/5.1/npm.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Npm",

--- a/specification/artifactsPackageTypes/5.1/nuGet.json
+++ b/specification/artifactsPackageTypes/5.1/nuGet.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "NuGet",

--- a/specification/artifactsPackageTypes/5.1/pyPiApi.json
+++ b/specification/artifactsPackageTypes/5.1/pyPiApi.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PyPiApi",

--- a/specification/artifactsPackageTypes/5.1/universal.json
+++ b/specification/artifactsPackageTypes/5.1/universal.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "UPackApi",

--- a/specification/artifactsPackageTypes/5.2/maven.json
+++ b/specification/artifactsPackageTypes/5.2/maven.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Maven",

--- a/specification/artifactsPackageTypes/5.2/npm.json
+++ b/specification/artifactsPackageTypes/5.2/npm.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Npm",

--- a/specification/artifactsPackageTypes/5.2/nuGet.json
+++ b/specification/artifactsPackageTypes/5.2/nuGet.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "NuGet",

--- a/specification/artifactsPackageTypes/5.2/pyPiApi.json
+++ b/specification/artifactsPackageTypes/5.2/pyPiApi.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PyPiApi",

--- a/specification/artifactsPackageTypes/5.2/universal.json
+++ b/specification/artifactsPackageTypes/5.2/universal.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "UPackApi",

--- a/specification/artifactsPackageTypes/6.0/maven.json
+++ b/specification/artifactsPackageTypes/6.0/maven.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Maven",

--- a/specification/artifactsPackageTypes/6.0/npm.json
+++ b/specification/artifactsPackageTypes/6.0/npm.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Npm",

--- a/specification/artifactsPackageTypes/6.0/nuGet.json
+++ b/specification/artifactsPackageTypes/6.0/nuGet.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "NuGet",

--- a/specification/artifactsPackageTypes/6.0/pyPiApi.json
+++ b/specification/artifactsPackageTypes/6.0/pyPiApi.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PyPiApi",

--- a/specification/artifactsPackageTypes/6.0/universal.json
+++ b/specification/artifactsPackageTypes/6.0/universal.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "UPackApi",

--- a/specification/artifactsPackageTypes/6.1/maven.json
+++ b/specification/artifactsPackageTypes/6.1/maven.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Maven",

--- a/specification/artifactsPackageTypes/6.1/npm.json
+++ b/specification/artifactsPackageTypes/6.1/npm.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Npm",

--- a/specification/artifactsPackageTypes/6.1/nuGet.json
+++ b/specification/artifactsPackageTypes/6.1/nuGet.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "NuGet",

--- a/specification/artifactsPackageTypes/6.1/pyPiApi.json
+++ b/specification/artifactsPackageTypes/6.1/pyPiApi.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PyPiApi",

--- a/specification/artifactsPackageTypes/6.1/universal.json
+++ b/specification/artifactsPackageTypes/6.1/universal.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "UPackApi",

--- a/specification/artifactsPackageTypes/7.1/maven.json
+++ b/specification/artifactsPackageTypes/7.1/maven.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Maven",

--- a/specification/artifactsPackageTypes/7.1/npm.json
+++ b/specification/artifactsPackageTypes/7.1/npm.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Npm",

--- a/specification/artifactsPackageTypes/7.1/nuGet.json
+++ b/specification/artifactsPackageTypes/7.1/nuGet.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "NuGet",

--- a/specification/artifactsPackageTypes/7.1/pyPiApi.json
+++ b/specification/artifactsPackageTypes/7.1/pyPiApi.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PyPiApi",

--- a/specification/artifactsPackageTypes/7.1/universal.json
+++ b/specification/artifactsPackageTypes/7.1/universal.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "UPackApi",

--- a/specification/artifactsPackageTypes/azure-devops-server-5.0/maven-onprem.json
+++ b/specification/artifactsPackageTypes/azure-devops-server-5.0/maven-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Maven",

--- a/specification/artifactsPackageTypes/azure-devops-server-5.0/npm-onprem.json
+++ b/specification/artifactsPackageTypes/azure-devops-server-5.0/npm-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Npm",

--- a/specification/artifactsPackageTypes/azure-devops-server-5.0/nuGet-onprem.json
+++ b/specification/artifactsPackageTypes/azure-devops-server-5.0/nuGet-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "NuGet",

--- a/specification/audit/5.1/audit.json
+++ b/specification/audit/5.1/audit.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Audit",

--- a/specification/audit/5.2/audit.json
+++ b/specification/audit/5.2/audit.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Audit",

--- a/specification/audit/6.0/audit.json
+++ b/specification/audit/6.0/audit.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Audit",

--- a/specification/audit/6.1/audit.json
+++ b/specification/audit/6.1/audit.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Audit",

--- a/specification/audit/7.1/audit.json
+++ b/specification/audit/7.1/audit.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Audit",

--- a/specification/build/4.1/build.json
+++ b/specification/build/4.1/build.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Build",

--- a/specification/build/5.0/build.json
+++ b/specification/build/5.0/build.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Build",

--- a/specification/build/5.1/build.json
+++ b/specification/build/5.1/build.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Build",

--- a/specification/build/5.2/build.json
+++ b/specification/build/5.2/build.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Build",

--- a/specification/build/6.0/build.json
+++ b/specification/build/6.0/build.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Build",

--- a/specification/build/6.1/build.json
+++ b/specification/build/6.1/build.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Build",

--- a/specification/build/7.1/build.json
+++ b/specification/build/7.1/build.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Build",

--- a/specification/build/azure-devops-server-5.0/build-onprem.json
+++ b/specification/build/azure-devops-server-5.0/build-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Build",

--- a/specification/build/tfs-4.1/build-onprem.json
+++ b/specification/build/tfs-4.1/build-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Build",

--- a/specification/clt/4.1/cloudLoadTest.json
+++ b/specification/clt/4.1/cloudLoadTest.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "CloudLoadTest",

--- a/specification/clt/5.0/cloudLoadTest.json
+++ b/specification/clt/5.0/cloudLoadTest.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "CloudLoadTest",

--- a/specification/clt/5.1/cloudLoadTest.json
+++ b/specification/clt/5.1/cloudLoadTest.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "CloudLoadTest",

--- a/specification/clt/5.2/cloudLoadTest.json
+++ b/specification/clt/5.2/cloudLoadTest.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "CloudLoadTest",

--- a/specification/clt/6.0/cloudLoadTest.json
+++ b/specification/clt/6.0/cloudLoadTest.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "CloudLoadTest",

--- a/specification/clt/6.1/cloudLoadTest.json
+++ b/specification/clt/6.1/cloudLoadTest.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "CloudLoadTest",

--- a/specification/clt/7.1/cloudLoadTest.json
+++ b/specification/clt/7.1/cloudLoadTest.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "CloudLoadTest",

--- a/specification/core/4.1/core.json
+++ b/specification/core/4.1/core.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Core",

--- a/specification/core/5.0/core.json
+++ b/specification/core/5.0/core.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Core",

--- a/specification/core/5.1/core.json
+++ b/specification/core/5.1/core.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Core",

--- a/specification/core/5.2/core.json
+++ b/specification/core/5.2/core.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Core",

--- a/specification/core/6.0/core.json
+++ b/specification/core/6.0/core.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Core",

--- a/specification/core/6.1/core.json
+++ b/specification/core/6.1/core.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Core",

--- a/specification/core/7.1/core.json
+++ b/specification/core/7.1/core.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Core",

--- a/specification/core/azure-devops-server-5.0/core-onprem.json
+++ b/specification/core/azure-devops-server-5.0/core-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Core",

--- a/specification/core/tfs-4.1/core-onprem.json
+++ b/specification/core/tfs-4.1/core-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Core",

--- a/specification/dashboard/4.1/dashboard.json
+++ b/specification/dashboard/4.1/dashboard.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Dashboard",

--- a/specification/dashboard/5.0/dashboard.json
+++ b/specification/dashboard/5.0/dashboard.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Dashboard",

--- a/specification/dashboard/5.1/dashboard.json
+++ b/specification/dashboard/5.1/dashboard.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Dashboard",

--- a/specification/dashboard/5.2/dashboard.json
+++ b/specification/dashboard/5.2/dashboard.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Dashboard",

--- a/specification/dashboard/6.0/dashboard.json
+++ b/specification/dashboard/6.0/dashboard.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Dashboard",

--- a/specification/dashboard/6.1/dashboard.json
+++ b/specification/dashboard/6.1/dashboard.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Dashboard",

--- a/specification/dashboard/7.1/dashboard.json
+++ b/specification/dashboard/7.1/dashboard.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Dashboard",

--- a/specification/dashboard/azure-devops-server-5.0/dashboard-onprem.json
+++ b/specification/dashboard/azure-devops-server-5.0/dashboard-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Dashboard",

--- a/specification/dashboard/tfs-4.1/dashboard-onprem.json
+++ b/specification/dashboard/tfs-4.1/dashboard-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Dashboard",

--- a/specification/distributedTask/4.1/taskAgent.json
+++ b/specification/distributedTask/4.1/taskAgent.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TaskAgent",

--- a/specification/distributedTask/5.0/taskAgent.json
+++ b/specification/distributedTask/5.0/taskAgent.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TaskAgent",

--- a/specification/distributedTask/5.1/taskAgent.json
+++ b/specification/distributedTask/5.1/taskAgent.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TaskAgent",

--- a/specification/distributedTask/5.2/taskAgent.json
+++ b/specification/distributedTask/5.2/taskAgent.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TaskAgent",

--- a/specification/distributedTask/6.0/taskAgent.json
+++ b/specification/distributedTask/6.0/taskAgent.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TaskAgent",

--- a/specification/distributedTask/6.1/elastic.json
+++ b/specification/distributedTask/6.1/elastic.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Elastic",

--- a/specification/distributedTask/6.1/taskAgent.json
+++ b/specification/distributedTask/6.1/taskAgent.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TaskAgent",

--- a/specification/distributedTask/7.1/elastic.json
+++ b/specification/distributedTask/7.1/elastic.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Elastic",

--- a/specification/distributedTask/7.1/taskAgent.json
+++ b/specification/distributedTask/7.1/taskAgent.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TaskAgent",

--- a/specification/distributedTask/azure-devops-server-5.0/taskAgent-onprem.json
+++ b/specification/distributedTask/azure-devops-server-5.0/taskAgent-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TaskAgent",

--- a/specification/distributedTask/tfs-4.1/taskAgent-onprem.json
+++ b/specification/distributedTask/tfs-4.1/taskAgent-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TaskAgent",

--- a/specification/extensionManagement/4.1/extensionManagement.json
+++ b/specification/extensionManagement/4.1/extensionManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ExtensionManagement",

--- a/specification/extensionManagement/5.0/extensionManagement.json
+++ b/specification/extensionManagement/5.0/extensionManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ExtensionManagement",

--- a/specification/extensionManagement/5.1/extensionManagement.json
+++ b/specification/extensionManagement/5.1/extensionManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ExtensionManagement",

--- a/specification/extensionManagement/5.2/extensionManagement.json
+++ b/specification/extensionManagement/5.2/extensionManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ExtensionManagement",

--- a/specification/extensionManagement/6.0/extensionManagement.json
+++ b/specification/extensionManagement/6.0/extensionManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ExtensionManagement",

--- a/specification/extensionManagement/6.1/extensionManagement.json
+++ b/specification/extensionManagement/6.1/extensionManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ExtensionManagement",

--- a/specification/extensionManagement/7.1/extensionManagement.json
+++ b/specification/extensionManagement/7.1/extensionManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ExtensionManagement",

--- a/specification/extensionManagement/azure-devops-server-5.0/extensionManagement-onprem.json
+++ b/specification/extensionManagement/azure-devops-server-5.0/extensionManagement-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ExtensionManagement",

--- a/specification/extensionManagement/tfs-4.1/extensionManagement-onprem.json
+++ b/specification/extensionManagement/tfs-4.1/extensionManagement-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ExtensionManagement",

--- a/specification/git/4.1/git.json
+++ b/specification/git/4.1/git.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Git",

--- a/specification/git/5.0/git.json
+++ b/specification/git/5.0/git.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Git",

--- a/specification/git/5.1/git.json
+++ b/specification/git/5.1/git.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Git",

--- a/specification/git/5.2/git.json
+++ b/specification/git/5.2/git.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Git",

--- a/specification/git/6.0/git.json
+++ b/specification/git/6.0/git.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Git",

--- a/specification/git/6.1/git.json
+++ b/specification/git/6.1/git.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Git",

--- a/specification/git/7.1/git.json
+++ b/specification/git/7.1/git.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Git",

--- a/specification/git/azure-devops-server-5.0/git-onprem.json
+++ b/specification/git/azure-devops-server-5.0/git-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Git",

--- a/specification/git/tfs-4.1/git-onprem.json
+++ b/specification/git/tfs-4.1/git-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Git",

--- a/specification/graph/4.1/graph.json
+++ b/specification/graph/4.1/graph.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Graph",

--- a/specification/graph/5.0/graph.json
+++ b/specification/graph/5.0/graph.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Graph",

--- a/specification/graph/5.1/graph.json
+++ b/specification/graph/5.1/graph.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Graph",

--- a/specification/graph/5.2/graph.json
+++ b/specification/graph/5.2/graph.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Graph",

--- a/specification/graph/6.0/graph.json
+++ b/specification/graph/6.0/graph.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Graph",

--- a/specification/graph/6.1/graph.json
+++ b/specification/graph/6.1/graph.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Graph",

--- a/specification/graph/7.1/graph.json
+++ b/specification/graph/7.1/graph.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Graph",

--- a/specification/hooks/4.1/serviceHooks.json
+++ b/specification/hooks/4.1/serviceHooks.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceHooks",

--- a/specification/hooks/5.0/serviceHooks.json
+++ b/specification/hooks/5.0/serviceHooks.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceHooks",

--- a/specification/hooks/5.1/serviceHooks.json
+++ b/specification/hooks/5.1/serviceHooks.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceHooks",

--- a/specification/hooks/5.2/serviceHooks.json
+++ b/specification/hooks/5.2/serviceHooks.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceHooks",

--- a/specification/hooks/6.0/serviceHooks.json
+++ b/specification/hooks/6.0/serviceHooks.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceHooks",

--- a/specification/hooks/6.1/serviceHooks.json
+++ b/specification/hooks/6.1/serviceHooks.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceHooks",

--- a/specification/hooks/7.1/serviceHooks.json
+++ b/specification/hooks/7.1/serviceHooks.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceHooks",

--- a/specification/hooks/azure-devops-server-5.0/serviceHooks-onprem.json
+++ b/specification/hooks/azure-devops-server-5.0/serviceHooks-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceHooks",

--- a/specification/hooks/tfs-4.1/serviceHooks-onprem.json
+++ b/specification/hooks/tfs-4.1/serviceHooks-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceHooks",

--- a/specification/ims/6.0/identities.json
+++ b/specification/ims/6.0/identities.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Identity",

--- a/specification/ims/6.1/identities.json
+++ b/specification/ims/6.1/identities.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Identity",

--- a/specification/ims/7.1/identities.json
+++ b/specification/ims/7.1/identities.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Identity",

--- a/specification/memberEntitlementManagement/4.1/memberEntitlementManagement.json
+++ b/specification/memberEntitlementManagement/4.1/memberEntitlementManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "MemberEntitlementManagement",

--- a/specification/memberEntitlementManagement/5.0/memberEntitlementManagement.json
+++ b/specification/memberEntitlementManagement/5.0/memberEntitlementManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "MemberEntitlementManagement",

--- a/specification/memberEntitlementManagement/5.1/memberEntitlementManagement.json
+++ b/specification/memberEntitlementManagement/5.1/memberEntitlementManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "MemberEntitlementManagement",

--- a/specification/memberEntitlementManagement/5.2/memberEntitlementManagement.json
+++ b/specification/memberEntitlementManagement/5.2/memberEntitlementManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "MemberEntitlementManagement",

--- a/specification/memberEntitlementManagement/6.0/memberEntitlementManagement.json
+++ b/specification/memberEntitlementManagement/6.0/memberEntitlementManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "MemberEntitlementManagement",

--- a/specification/memberEntitlementManagement/6.1/memberEntitlementManagement.json
+++ b/specification/memberEntitlementManagement/6.1/memberEntitlementManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "MemberEntitlementManagement",

--- a/specification/memberEntitlementManagement/7.1/memberEntitlementManagement.json
+++ b/specification/memberEntitlementManagement/7.1/memberEntitlementManagement.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "MemberEntitlementManagement",

--- a/specification/notification/4.1/notification.json
+++ b/specification/notification/4.1/notification.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Notification",

--- a/specification/notification/5.0/notification.json
+++ b/specification/notification/5.0/notification.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Notification",

--- a/specification/notification/5.1/notification.json
+++ b/specification/notification/5.1/notification.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Notification",

--- a/specification/notification/5.2/notification.json
+++ b/specification/notification/5.2/notification.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Notification",

--- a/specification/notification/6.0/notification.json
+++ b/specification/notification/6.0/notification.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Notification",

--- a/specification/notification/6.1/notification.json
+++ b/specification/notification/6.1/notification.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Notification",

--- a/specification/notification/7.1/notification.json
+++ b/specification/notification/7.1/notification.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Notification",

--- a/specification/notification/azure-devops-server-5.0/notification-onprem.json
+++ b/specification/notification/azure-devops-server-5.0/notification-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Notification",

--- a/specification/notification/tfs-4.1/notification-onprem.json
+++ b/specification/notification/tfs-4.1/notification-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Notification",

--- a/specification/operations/4.1/operations.json
+++ b/specification/operations/4.1/operations.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Operations",

--- a/specification/operations/5.0/operations.json
+++ b/specification/operations/5.0/operations.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Operations",

--- a/specification/operations/5.1/operations.json
+++ b/specification/operations/5.1/operations.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Operations",

--- a/specification/operations/5.2/operations.json
+++ b/specification/operations/5.2/operations.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Operations",

--- a/specification/operations/6.0/operations.json
+++ b/specification/operations/6.0/operations.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Operations",

--- a/specification/operations/6.1/operations.json
+++ b/specification/operations/6.1/operations.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Operations",

--- a/specification/operations/7.1/operations.json
+++ b/specification/operations/7.1/operations.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Operations",

--- a/specification/operations/azure-devops-server-5.0/operations-onprem.json
+++ b/specification/operations/azure-devops-server-5.0/operations-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Operations",

--- a/specification/operations/tfs-4.1/operations-onprem.json
+++ b/specification/operations/tfs-4.1/operations-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Operations",

--- a/specification/permissionsReport/6.0/permissionsReport.json
+++ b/specification/permissionsReport/6.0/permissionsReport.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PermissionsReport",

--- a/specification/permissionsReport/6.1/permissionsReport.json
+++ b/specification/permissionsReport/6.1/permissionsReport.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PermissionsReport",

--- a/specification/permissionsReport/7.1/permissionsReport.json
+++ b/specification/permissionsReport/7.1/permissionsReport.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "PermissionsReport",

--- a/specification/pipelines/6.0/pipelines.json
+++ b/specification/pipelines/6.0/pipelines.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Pipelines",

--- a/specification/pipelines/6.1/pipelines.json
+++ b/specification/pipelines/6.1/pipelines.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Pipelines",

--- a/specification/pipelines/7.1/pipelines.json
+++ b/specification/pipelines/7.1/pipelines.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Pipelines",

--- a/specification/policy/4.1/policy.json
+++ b/specification/policy/4.1/policy.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Policy",

--- a/specification/policy/5.0/policy.json
+++ b/specification/policy/5.0/policy.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Policy",

--- a/specification/policy/5.1/policy.json
+++ b/specification/policy/5.1/policy.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Policy",

--- a/specification/policy/5.2/policy.json
+++ b/specification/policy/5.2/policy.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Policy",

--- a/specification/policy/6.0/policy.json
+++ b/specification/policy/6.0/policy.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Policy",

--- a/specification/policy/6.1/policy.json
+++ b/specification/policy/6.1/policy.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Policy",

--- a/specification/policy/7.1/policy.json
+++ b/specification/policy/7.1/policy.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Policy",

--- a/specification/policy/azure-devops-server-5.0/policy-onprem.json
+++ b/specification/policy/azure-devops-server-5.0/policy-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Policy",

--- a/specification/policy/tfs-4.1/policy-onprem.json
+++ b/specification/policy/tfs-4.1/policy-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Policy",

--- a/specification/processDefinitions/4.1/workItemTrackingProcessDefinitions.json
+++ b/specification/processDefinitions/4.1/workItemTrackingProcessDefinitions.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/processDefinitions/tfs-4.1/workItemTrackingProcessDefinitions-onprem.json
+++ b/specification/processDefinitions/tfs-4.1/workItemTrackingProcessDefinitions-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/processadmin/4.1/workItemTrackingProcessTemplate.json
+++ b/specification/processadmin/4.1/workItemTrackingProcessTemplate.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTrackingProcessTemplate",

--- a/specification/processadmin/5.0/workItemTrackingProcessTemplate.json
+++ b/specification/processadmin/5.0/workItemTrackingProcessTemplate.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTrackingProcessTemplate",

--- a/specification/processadmin/5.1/workItemTrackingProcessTemplate.json
+++ b/specification/processadmin/5.1/workItemTrackingProcessTemplate.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTrackingProcessTemplate",

--- a/specification/processadmin/5.2/workItemTrackingProcessTemplate.json
+++ b/specification/processadmin/5.2/workItemTrackingProcessTemplate.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTrackingProcessTemplate",

--- a/specification/processadmin/6.0/workItemTrackingProcessTemplate.json
+++ b/specification/processadmin/6.0/workItemTrackingProcessTemplate.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTrackingProcessTemplate",

--- a/specification/processadmin/6.1/workItemTrackingProcessTemplate.json
+++ b/specification/processadmin/6.1/workItemTrackingProcessTemplate.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTrackingProcessTemplate",

--- a/specification/processadmin/7.1/workItemTrackingProcessTemplate.json
+++ b/specification/processadmin/7.1/workItemTrackingProcessTemplate.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTrackingProcessTemplate",

--- a/specification/processadmin/azure-devops-server-5.0/workItemTrackingProcessTemplate-onprem.json
+++ b/specification/processadmin/azure-devops-server-5.0/workItemTrackingProcessTemplate-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTrackingProcessTemplate",

--- a/specification/processadmin/tfs-4.1/workItemTrackingProcessTemplate-onprem.json
+++ b/specification/processadmin/tfs-4.1/workItemTrackingProcessTemplate-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTrackingProcessTemplate",

--- a/specification/processes/4.1/workItemTrackingProcess.json
+++ b/specification/processes/4.1/workItemTrackingProcess.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/processes/5.0/workItemTrackingProcess.json
+++ b/specification/processes/5.0/workItemTrackingProcess.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/processes/5.1/workItemTrackingProcess.json
+++ b/specification/processes/5.1/workItemTrackingProcess.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/processes/5.2/workItemTrackingProcess.json
+++ b/specification/processes/5.2/workItemTrackingProcess.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/processes/6.0/workItemTrackingProcess.json
+++ b/specification/processes/6.0/workItemTrackingProcess.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/processes/6.1/workItemTrackingProcess.json
+++ b/specification/processes/6.1/workItemTrackingProcess.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/processes/7.1/workItemTrackingProcess.json
+++ b/specification/processes/7.1/workItemTrackingProcess.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/processes/azure-devops-server-5.0/workItemTrackingProcess-onprem.json
+++ b/specification/processes/azure-devops-server-5.0/workItemTrackingProcess-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/processes/tfs-4.1/workItemTrackingProcess-onprem.json
+++ b/specification/processes/tfs-4.1/workItemTrackingProcess-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/profile/4.1/profile.json
+++ b/specification/profile/4.1/profile.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Profile",

--- a/specification/profile/5.0/profile.json
+++ b/specification/profile/5.0/profile.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Profile",

--- a/specification/profile/5.1/profile.json
+++ b/specification/profile/5.1/profile.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Profile",

--- a/specification/profile/5.2/profile.json
+++ b/specification/profile/5.2/profile.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Profile",

--- a/specification/profile/6.0/profile.json
+++ b/specification/profile/6.0/profile.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Profile",

--- a/specification/profile/6.1/profile.json
+++ b/specification/profile/6.1/profile.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Profile",

--- a/specification/profile/7.1/profile.json
+++ b/specification/profile/7.1/profile.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Profile",

--- a/specification/release/4.1/release.json
+++ b/specification/release/4.1/release.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Release",

--- a/specification/release/5.0/release.json
+++ b/specification/release/5.0/release.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Release",

--- a/specification/release/5.1/release.json
+++ b/specification/release/5.1/release.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Release",

--- a/specification/release/5.2/release.json
+++ b/specification/release/5.2/release.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Release",

--- a/specification/release/6.0/release.json
+++ b/specification/release/6.0/release.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Release",

--- a/specification/release/6.1/release.json
+++ b/specification/release/6.1/release.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Release",

--- a/specification/release/7.1/release.json
+++ b/specification/release/7.1/release.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Release",

--- a/specification/release/azure-devops-server-5.0/release-onprem.json
+++ b/specification/release/azure-devops-server-5.0/release-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Release",

--- a/specification/release/tfs-4.1/release-onprem.json
+++ b/specification/release/tfs-4.1/release-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Release",

--- a/specification/search/4.1/search.json
+++ b/specification/search/4.1/search.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Search",

--- a/specification/search/5.0/search.json
+++ b/specification/search/5.0/search.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Search",

--- a/specification/search/5.1/search.json
+++ b/specification/search/5.1/search.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Search",

--- a/specification/search/5.2/search.json
+++ b/specification/search/5.2/search.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Search",

--- a/specification/search/6.0/search.json
+++ b/specification/search/6.0/search.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Search",

--- a/specification/search/6.1/search.json
+++ b/specification/search/6.1/search.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Search",

--- a/specification/search/7.1/search.json
+++ b/specification/search/7.1/search.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Search",

--- a/specification/search/azure-devops-server-5.0/search-onprem.json
+++ b/specification/search/azure-devops-server-5.0/search-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Search",

--- a/specification/search/tfs-4.1/search-onprem.json
+++ b/specification/search/tfs-4.1/search-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Search",

--- a/specification/security/4.1/security.json
+++ b/specification/security/4.1/security.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Security",

--- a/specification/security/5.0/security.json
+++ b/specification/security/5.0/security.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Security",

--- a/specification/security/5.1/security.json
+++ b/specification/security/5.1/security.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Security",

--- a/specification/security/5.2/security.json
+++ b/specification/security/5.2/security.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Security",

--- a/specification/security/6.0/security.json
+++ b/specification/security/6.0/security.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Security",

--- a/specification/security/6.1/security.json
+++ b/specification/security/6.1/security.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Security",

--- a/specification/security/7.1/security.json
+++ b/specification/security/7.1/security.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Security",

--- a/specification/security/azure-devops-server-5.0/security-onprem.json
+++ b/specification/security/azure-devops-server-5.0/security-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Security",

--- a/specification/security/tfs-4.1/security-onprem.json
+++ b/specification/security/tfs-4.1/security-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Security",

--- a/specification/securityRoles/6.1/securityRoles.json
+++ b/specification/securityRoles/6.1/securityRoles.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "SecurityRoles",

--- a/specification/securityRoles/7.1/securityRoles.json
+++ b/specification/securityRoles/7.1/securityRoles.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "SecurityRoles",

--- a/specification/serviceEndpoint/4.1/serviceEndpoint.json
+++ b/specification/serviceEndpoint/4.1/serviceEndpoint.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceEndpoint",

--- a/specification/serviceEndpoint/5.0/serviceEndpoint.json
+++ b/specification/serviceEndpoint/5.0/serviceEndpoint.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceEndpoint",

--- a/specification/serviceEndpoint/5.1/serviceEndpoint.json
+++ b/specification/serviceEndpoint/5.1/serviceEndpoint.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceEndpoint",

--- a/specification/serviceEndpoint/5.2/serviceEndpoint.json
+++ b/specification/serviceEndpoint/5.2/serviceEndpoint.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceEndpoint",

--- a/specification/serviceEndpoint/6.0/serviceEndpoint.json
+++ b/specification/serviceEndpoint/6.0/serviceEndpoint.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceEndpoint",

--- a/specification/serviceEndpoint/6.1/serviceEndpoint.json
+++ b/specification/serviceEndpoint/6.1/serviceEndpoint.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceEndpoint",

--- a/specification/serviceEndpoint/7.1/serviceEndpoint.json
+++ b/specification/serviceEndpoint/7.1/serviceEndpoint.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceEndpoint",

--- a/specification/serviceEndpoint/azure-devops-server-5.0/serviceEndpoint-onprem.json
+++ b/specification/serviceEndpoint/azure-devops-server-5.0/serviceEndpoint-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceEndpoint",

--- a/specification/serviceEndpoint/tfs-4.1/serviceEndpoint-onprem.json
+++ b/specification/serviceEndpoint/tfs-4.1/serviceEndpoint-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "ServiceEndpoint",

--- a/specification/status/6.0/status.json
+++ b/specification/status/6.0/status.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Status",

--- a/specification/status/6.1/status.json
+++ b/specification/status/6.1/status.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Status",

--- a/specification/status/7.1/status.json
+++ b/specification/status/7.1/status.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Status",

--- a/specification/symbol/4.1/symbol.json
+++ b/specification/symbol/4.1/symbol.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Symbol",

--- a/specification/symbol/5.0/symbol.json
+++ b/specification/symbol/5.0/symbol.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Symbol",

--- a/specification/symbol/5.1/symbol.json
+++ b/specification/symbol/5.1/symbol.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Symbol",

--- a/specification/symbol/5.2/symbol.json
+++ b/specification/symbol/5.2/symbol.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Symbol",

--- a/specification/symbol/6.0/symbol.json
+++ b/specification/symbol/6.0/symbol.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Symbol",

--- a/specification/symbol/6.1/symbol.json
+++ b/specification/symbol/6.1/symbol.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Symbol",

--- a/specification/symbol/7.1/symbol.json
+++ b/specification/symbol/7.1/symbol.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Symbol",

--- a/specification/test/5.0/test.json
+++ b/specification/test/5.0/test.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Test",

--- a/specification/test/5.1/test.json
+++ b/specification/test/5.1/test.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Test",

--- a/specification/test/5.2/test.json
+++ b/specification/test/5.2/test.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Test",

--- a/specification/test/6.0/test.json
+++ b/specification/test/6.0/test.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Test",

--- a/specification/test/6.1/test.json
+++ b/specification/test/6.1/test.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Test",

--- a/specification/test/7.1/test.json
+++ b/specification/test/7.1/test.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Test",

--- a/specification/test/azure-devops-server-5.0/test-onprem.json
+++ b/specification/test/azure-devops-server-5.0/test-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Test",

--- a/specification/testPlan/5.0/testPlan.json
+++ b/specification/testPlan/5.0/testPlan.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TestPlan",

--- a/specification/testPlan/5.1/testPlan.json
+++ b/specification/testPlan/5.1/testPlan.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TestPlan",

--- a/specification/testPlan/5.2/testPlan.json
+++ b/specification/testPlan/5.2/testPlan.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TestPlan",

--- a/specification/testPlan/6.0/testPlan.json
+++ b/specification/testPlan/6.0/testPlan.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TestPlan",

--- a/specification/testPlan/6.1/testPlan.json
+++ b/specification/testPlan/6.1/testPlan.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TestPlan",

--- a/specification/testPlan/7.1/testPlan.json
+++ b/specification/testPlan/7.1/testPlan.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TestPlan",

--- a/specification/testPlan/azure-devops-server-5.0/testPlan-onprem.json
+++ b/specification/testPlan/azure-devops-server-5.0/testPlan-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TestPlan",

--- a/specification/testResults/5.2/testResults.json
+++ b/specification/testResults/5.2/testResults.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TestResults",

--- a/specification/testResults/6.0/testResults.json
+++ b/specification/testResults/6.0/testResults.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TestResults",

--- a/specification/testResults/6.1/testResults.json
+++ b/specification/testResults/6.1/testResults.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TestResults",

--- a/specification/testResults/7.1/testResults.json
+++ b/specification/testResults/7.1/testResults.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TestResults",

--- a/specification/tfvc/4.1/tfvc.json
+++ b/specification/tfvc/4.1/tfvc.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Tfvc",

--- a/specification/tfvc/5.0/tfvc.json
+++ b/specification/tfvc/5.0/tfvc.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Tfvc",

--- a/specification/tfvc/5.1/tfvc.json
+++ b/specification/tfvc/5.1/tfvc.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Tfvc",

--- a/specification/tfvc/5.2/tfvc.json
+++ b/specification/tfvc/5.2/tfvc.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Tfvc",

--- a/specification/tfvc/6.0/tfvc.json
+++ b/specification/tfvc/6.0/tfvc.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Tfvc",

--- a/specification/tfvc/6.1/tfvc.json
+++ b/specification/tfvc/6.1/tfvc.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Tfvc",

--- a/specification/tfvc/7.1/tfvc.json
+++ b/specification/tfvc/7.1/tfvc.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Tfvc",

--- a/specification/tfvc/azure-devops-server-5.0/tfvc-onprem.json
+++ b/specification/tfvc/azure-devops-server-5.0/tfvc-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Tfvc",

--- a/specification/tfvc/tfs-4.1/tfvc-onprem.json
+++ b/specification/tfvc/tfs-4.1/tfvc-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Tfvc",

--- a/specification/tokenAdmin/5.0/tokenAdmin.json
+++ b/specification/tokenAdmin/5.0/tokenAdmin.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TokenAdmin",

--- a/specification/tokenAdmin/5.1/tokenAdmin.json
+++ b/specification/tokenAdmin/5.1/tokenAdmin.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TokenAdmin",

--- a/specification/tokenAdmin/5.2/tokenAdmin.json
+++ b/specification/tokenAdmin/5.2/tokenAdmin.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TokenAdmin",

--- a/specification/tokenAdmin/6.0/tokenAdmin.json
+++ b/specification/tokenAdmin/6.0/tokenAdmin.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TokenAdmin",

--- a/specification/tokenAdmin/6.1/tokenAdmin.json
+++ b/specification/tokenAdmin/6.1/tokenAdmin.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TokenAdmin",

--- a/specification/tokenAdmin/7.1/tokenAdmin.json
+++ b/specification/tokenAdmin/7.1/tokenAdmin.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TokenAdmin",

--- a/specification/tokenAdmin/azure-devops-server-5.0/tokenAdmin-onprem.json
+++ b/specification/tokenAdmin/azure-devops-server-5.0/tokenAdmin-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TokenAdmin",

--- a/specification/tokenAdministration/5.0/tokenAdministration.json
+++ b/specification/tokenAdministration/5.0/tokenAdministration.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TokenAdministration",

--- a/specification/tokenAdministration/5.1/tokenAdministration.json
+++ b/specification/tokenAdministration/5.1/tokenAdministration.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TokenAdministration",

--- a/specification/tokenAdministration/5.2/tokenAdministration.json
+++ b/specification/tokenAdministration/5.2/tokenAdministration.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "TokenAdministration",

--- a/specification/tokens/6.1/tokens.json
+++ b/specification/tokens/6.1/tokens.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Tokens",

--- a/specification/tokens/7.1/tokens.json
+++ b/specification/tokens/7.1/tokens.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Tokens",

--- a/specification/wiki/4.1/wiki.json
+++ b/specification/wiki/4.1/wiki.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Wiki",

--- a/specification/wiki/5.0/wiki.json
+++ b/specification/wiki/5.0/wiki.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Wiki",

--- a/specification/wiki/5.1/wiki.json
+++ b/specification/wiki/5.1/wiki.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Wiki",

--- a/specification/wiki/5.2/wiki.json
+++ b/specification/wiki/5.2/wiki.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Wiki",

--- a/specification/wiki/6.0/wiki.json
+++ b/specification/wiki/6.0/wiki.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Wiki",

--- a/specification/wiki/6.1/wiki.json
+++ b/specification/wiki/6.1/wiki.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Wiki",

--- a/specification/wiki/7.1/wiki.json
+++ b/specification/wiki/7.1/wiki.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Wiki",

--- a/specification/wiki/azure-devops-server-5.0/wiki-onprem.json
+++ b/specification/wiki/azure-devops-server-5.0/wiki-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Wiki",

--- a/specification/wiki/tfs-4.1/wiki-onprem.json
+++ b/specification/wiki/tfs-4.1/wiki-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Wiki",

--- a/specification/wit/4.1/workItemTracking.json
+++ b/specification/wit/4.1/workItemTracking.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/wit/5.0/workItemTracking.json
+++ b/specification/wit/5.0/workItemTracking.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/wit/5.1/workItemTracking.json
+++ b/specification/wit/5.1/workItemTracking.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/wit/5.2/workItemTracking.json
+++ b/specification/wit/5.2/workItemTracking.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/wit/6.0/workItemTracking.json
+++ b/specification/wit/6.0/workItemTracking.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/wit/6.1/workItemTracking.json
+++ b/specification/wit/6.1/workItemTracking.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/wit/7.1/workItemTracking.json
+++ b/specification/wit/7.1/workItemTracking.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/wit/azure-devops-server-5.0/workItemTracking-onprem.json
+++ b/specification/wit/azure-devops-server-5.0/workItemTracking-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/wit/tfs-4.1/workItemTracking-onprem.json
+++ b/specification/wit/tfs-4.1/workItemTracking-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "WorkItemTracking",

--- a/specification/work/4.1/work.json
+++ b/specification/work/4.1/work.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Work",

--- a/specification/work/5.0/work.json
+++ b/specification/work/5.0/work.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Work",

--- a/specification/work/5.1/work.json
+++ b/specification/work/5.1/work.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Work",

--- a/specification/work/5.2/work.json
+++ b/specification/work/5.2/work.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Work",

--- a/specification/work/6.0/work.json
+++ b/specification/work/6.0/work.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Work",

--- a/specification/work/6.1/work.json
+++ b/specification/work/6.1/work.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Work",

--- a/specification/work/7.1/work.json
+++ b/specification/work/7.1/work.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Work",

--- a/specification/work/azure-devops-server-5.0/work-onprem.json
+++ b/specification/work/azure-devops-server-5.0/work-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Work",

--- a/specification/work/tfs-4.1/work-onprem.json
+++ b/specification/work/tfs-4.1/work-onprem.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "Work",


### PR DESCRIPTION
Fixes #487 by removing the bytes order marks. The code generator from the Azure SDK for Rust also needs them removed. This code was used to remove the BOMs: https://github.com/Azure/azure-sdk-for-rust/pull/660. The Hex Editor by Microsoft for VSCode can be used to inspect the files.