### PR TITLE
Updated the continuation token type

### DIFF
--- a/specification/core/7.1/core.json
+++ b/specification/core/7.1/core.json
@@ -226,9 +226,10 @@
           {
             "in": "query",
             "name": "continuationToken",
-            "description": "",
+            "description": "Pointer that shows how many projects already been fetched.",
             "required": false,
-            "type": "string"
+            "type": "integer",
+            "format": "int32"
           },
           {
             "in": "query",


### PR DESCRIPTION
Continuation token type has changed from `string` to `number` (int 32) in the PR 697926