### PR TITLE
fix common typo for 'permissions'

### DIFF
--- a/specification/approvalsAndChecks/6.1/pipelinePermissions.json
+++ b/specification/approvalsAndChecks/6.1/pipelinePermissions.json
@@ -34,10 +34,10 @@
         ],
         "x-ms-docs-override-version": "6.1-preview.1",
         "x-ms-vss-resource": "pipelinePermissions",
-        "x-ms-vss-method": "UpdatePipelinePermisionsForResources",
+        "x-ms-vss-method": "UpdatePipelinePermissionsForResources",
         "x-ms-preview": true,
         "description": "Batch API to authorize/unauthorize a list of definitions for a multiple resources.",
-        "operationId": "Pipeline Permissions_Update Pipeline Permisions For Resources",
+        "operationId": "Pipeline Permissions_Update Pipeline Permissions For Resources",
         "consumes": [
           "application/json"
         ],
@@ -160,10 +160,10 @@
         ],
         "x-ms-docs-override-version": "6.1-preview.1",
         "x-ms-vss-resource": "pipelinePermissions",
-        "x-ms-vss-method": "UpdatePipelinePermisionsForResource",
+        "x-ms-vss-method": "UpdatePipelinePermissionsForResource",
         "x-ms-preview": true,
         "description": "Authorizes/Unauthorizes a list of definitions for a given resource.",
-        "operationId": "Pipeline Permissions_Update Pipeline Permisions For Resource",
+        "operationId": "Pipeline Permissions_Update Pipeline Permissions For Resource",
         "consumes": [
           "application/json"
         ],

--- a/specification/approvalsAndChecks/7.0/pipelinePermissions.json
+++ b/specification/approvalsAndChecks/7.0/pipelinePermissions.json
@@ -34,7 +34,7 @@
         ],
         "x-ms-docs-override-version": "7.0-preview.1",
         "x-ms-vss-resource": "pipelinePermissions",
-        "x-ms-vss-method": "UpdatePipelinePermisionsForResources",
+        "x-ms-vss-method": "UpdatePipelinePermissionsForResources",
         "x-ms-preview": true,
         "description": "Batch API to authorize/unauthorize a list of definitions for a multiple resources.",
         "operationId": "Pipeline Permissions_Update Pipeline Permisions For Resources",

--- a/specification/approvalsAndChecks/7.1/pipelinePermissions.json
+++ b/specification/approvalsAndChecks/7.1/pipelinePermissions.json
@@ -34,10 +34,10 @@
         ],
         "x-ms-docs-override-version": "7.1-preview.1",
         "x-ms-vss-resource": "pipelinePermissions",
-        "x-ms-vss-method": "UpdatePipelinePermisionsForResources",
+        "x-ms-vss-method": "UpdatePipelinePermissionsForResources",
         "x-ms-preview": true,
         "description": "Batch API to authorize/unauthorize a list of definitions for a multiple resources.",
-        "operationId": "Pipeline Permissions_Update Pipeline Permisions For Resources",
+        "operationId": "Pipeline Permissions_Update Pipeline Permissions For Resources",
         "consumes": [
           "application/json"
         ],
@@ -174,10 +174,10 @@
         ],
         "x-ms-docs-override-version": "7.1-preview.1",
         "x-ms-vss-resource": "pipelinePermissions",
-        "x-ms-vss-method": "UpdatePipelinePermisionsForResource",
+        "x-ms-vss-method": "UpdatePipelinePermissionsForResource",
         "x-ms-preview": true,
         "description": "Authorizes/Unauthorizes a list of definitions for a given resource.",
-        "operationId": "Pipeline Permissions_Update Pipeline Permisions For Resource",
+        "operationId": "Pipeline Permissions_Update Pipeline Permissions For Resource",
         "consumes": [
           "application/json"
         ],

--- a/specification/approvalsAndChecks/azure-devops-server-7.0/pipelinePermissions-onprem.json
+++ b/specification/approvalsAndChecks/azure-devops-server-7.0/pipelinePermissions-onprem.json
@@ -34,10 +34,10 @@
         ],
         "x-ms-docs-override-version": "7.0-preview.1",
         "x-ms-vss-resource": "pipelinePermissions",
-        "x-ms-vss-method": "UpdatePipelinePermisionsForResources",
+        "x-ms-vss-method": "UpdatePipelinePermissionsForResources",
         "x-ms-preview": true,
         "description": "Batch API to authorize/unauthorize a list of definitions for a multiple resources.",
-        "operationId": "Pipeline Permissions_Update Pipeline Permisions For Resources",
+        "operationId": "Pipeline Permissions_Update Pipeline Permissions For Resources",
         "consumes": [
           "application/json"
         ],
@@ -160,10 +160,10 @@
         ],
         "x-ms-docs-override-version": "7.0-preview.1",
         "x-ms-vss-resource": "pipelinePermissions",
-        "x-ms-vss-method": "UpdatePipelinePermisionsForResource",
+        "x-ms-vss-method": "UpdatePipelinePermissionsForResource",
         "x-ms-preview": true,
         "description": "Authorizes/Unauthorizes a list of definitions for a given resource.",
-        "operationId": "Pipeline Permissions_Update Pipeline Permisions For Resource",
+        "operationId": "Pipeline Permissions_Update Pipeline Permissions For Resource",
         "consumes": [
           "application/json"
         ],

--- a/specification/permissionsReport/6.0/permissionsReport.json
+++ b/specification/permissionsReport/6.0/permissionsReport.json
@@ -285,7 +285,7 @@
           "type": "string"
         },
         "resources": {
-          "description": "List of resources to fetch permisions on",
+          "description": "List of resources to fetch permissions on",
           "type": "array",
           "items": {
             "$ref": "#/definitions/PermissionsReportResource"

--- a/specification/permissionsReport/6.1/permissionsReport.json
+++ b/specification/permissionsReport/6.1/permissionsReport.json
@@ -285,7 +285,7 @@
           "type": "string"
         },
         "resources": {
-          "description": "List of resources to fetch permisions on",
+          "description": "List of resources to fetch permissions on",
           "type": "array",
           "items": {
             "$ref": "#/definitions/PermissionsReportResource"

--- a/specification/permissionsReport/7.0/permissionsReport.json
+++ b/specification/permissionsReport/7.0/permissionsReport.json
@@ -281,7 +281,7 @@
           "type": "string"
         },
         "resources": {
-          "description": "List of resources to fetch permisions on",
+          "description": "List of resources to fetch permissions on",
           "type": "array",
           "items": {
             "$ref": "#/definitions/PermissionsReportResource"

--- a/specification/permissionsReport/7.1/permissionsReport.json
+++ b/specification/permissionsReport/7.1/permissionsReport.json
@@ -313,7 +313,7 @@
           "type": "string"
         },
         "resources": {
-          "description": "List of resources to fetch permisions on",
+          "description": "List of resources to fetch permissions on",
           "type": "array",
           "items": {
             "$ref": "#/definitions/PermissionsReportResource"


### PR DESCRIPTION
There is a common misspelling ('permision') for the string 'permission' and 'permissions'. See attached image. 

![image](https://github.com/MicrosoftDocs/vsts-rest-api-specs/assets/9373098/7a56e44c-dddd-4869-9d0b-76cf9347613a)
